### PR TITLE
refine distill-inspired theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: dev
+
+dev:
+	hugo server -D

--- a/themes/hugo-distill/layouts/_default/baseof.html
+++ b/themes/hugo-distill/layouts/_default/baseof.html
@@ -21,65 +21,28 @@
 </html>
 
 <style>
-  /* Reset box sizing */
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-
-  /* Basic reset for html and body */
   html,
   body {
-    height: 100%;
-    margin: 0;
-    padding: 0;
+    min-height: 100%;
   }
 
-  /* Grid-based page layout */
   .page-layout {
     min-height: 100vh;
     display: grid;
     grid-template-rows: auto 1fr auto;
-    grid-template-areas:
-      'header'
-      'main'
-      'footer';
   }
 
-  /* Header styles */
   .main-header {
-    grid-area: header;
-    height: var(--nav-height);
-    background-color: #fff;
-    display: flex;
-    align-items: stretch;
+    background: var(--brand-ink);
   }
 
-  .main-header nav {
-    width: 100%;
-  }
-
-  /* Main content area */
   .site-main {
-    grid-area: main;
     width: 100%;
-    padding: 2rem 0;
-    background-color: #fff;
+    padding: 0 0 4rem;
+    background: #fff;
   }
 
-  /* Container for content width constraint */
-  .container {
-    max-width: calc(var(--main-width) + 2 * var(--gutter));
-    margin: 0 auto;
-    padding: 0 var(--gutter);
-  }
-
-  /* Footer styles */
   .site-footer {
-    grid-area: footer;
-    height: var(--nav-height);
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    background-color: #fff;
+    background: var(--brand-ink);
   }
 </style>

--- a/themes/hugo-distill/layouts/_default/list.html
+++ b/themes/hugo-distill/layouts/_default/list.html
@@ -1,257 +1,219 @@
 {{ define "main" }}
 <div class="article-list">
-    <!-- Articles Collection -->
-    <div class="articles-collection">
-        {{ if or .IsHome (eq .Section "posts") }}
-            {{ $pages := cond .IsHome (where .Site.RegularPages "Section" "posts") .Pages }}
-            {{ range $pages.ByDate.Reverse }}
-            <article class="article-card">
-                <a href="{{ .RelPermalink }}" class="article-card-link">
-                    <div class="article-date">
-                        <time datetime="{{ .Date.Format "2006-01-02" }}">
-                            {{ .Date.Format "Jan 2, 2006" }}
-                        </time>
-                    </div>
-                    
-                    <div class="article-main-content">
-                        <div class="article-meta">
-                            {{ if .Params.peer_reviewed }}
-                                <span class="article-tag peer-reviewed">PEER-REVIEWED</span>
-                            {{ end }}
-                            {{ if .Draft }}
-                                <div class="draft-info">
-                                    <span class="article-tag draft">DRAFT</span>
-                                    {{ with .Params.progress }}
-                                        <div class="progress-bar">
-                                            <div class="progress" style="width: {{ . }}%"></div>
-                                        </div>
-                                    {{ end }}
-                                    {{ with .Params.status }}
-                                        <span class="status">{{ . }}</span>
-                                    {{ end }}
-                                </div>
-                            {{ end }}
-                        </div>
+  <div class="articles-collection">
+    {{ if or .IsHome (eq .Section "posts") }}
+      {{ $pages := cond .IsHome (where .Site.RegularPages "Section" "posts") .Pages }}
+      {{ range $pages.ByDate.Reverse }}
+      <article class="post-preview{{ if .Params.peer_reviewed }} peer-reviewed{{ end }}">
+        <div class="metadata">
+          <div class="published-date">
+            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan. 2, 2006" }}</time>
+          </div>
 
-                        <div class="article-content">
-                            <header class="article-header">
-                                <h2 class="article-title">
-                                    <span class="title-text">{{ .Title }}</span>
-                                </h2>
-                                {{ with .Params.authors }}
-                                    <div class="article-authors">
-                                        {{ delimit . ", " }}
-                                    </div>
-                                {{ end }}
-                            </header>
-
-                            <div class="article-abstract">
-                                {{ with .Params.abstract }}
-                                    {{ . | markdownify }}
-                                {{ else }}
-                                    <p>{{ .Summary }}</p>
-                                {{ end }}
-                            </div>
-
-                            {{ with .Params.thumbnail }}
-                                <div class="article-thumbnail">
-                                    <img src="{{ . }}" alt="Thumbnail for {{ $.Title }}">
-                                </div>
-                            {{ end }}
-                        </div>
-                    </div>
-                </a>
-            </article>
+          <div class="tags">
+            {{ if .Params.peer_reviewed }}
+            <span class="tag peer-reviewed">Peer-reviewed</span>
+            {{ else if .Params.category }}
+            <span class="tag">{{ .Params.category }}</span>
+            {{ else if .Draft }}
+            <span class="tag">Draft</span>
             {{ end }}
-        {{ end }}
-    </div>
+          </div>
+        </div>
+
+        <a href="{{ .RelPermalink }}" class="post-link{{ if not .Params.thumbnail }} no-thumbnail{{ end }}">
+          {{ with .Params.thumbnail }}
+          <div class="thumbnail">
+            <img src="{{ . }}" alt="Thumbnail for {{ $.Title }}">
+          </div>
+          {{ end }}
+
+          <div class="description{{ if not .Params.thumbnail }} no-thumbnail{{ end }}">
+            <h2 class="title">{{ .Title }}</h2>
+
+            {{ with .Params.authors }}
+            <p class="authors">{{ delimit . ", " }}</p>
+            {{ else }}
+            {{ with .Params.author }}
+            <p class="authors">{{ . }}</p>
+            {{ end }}
+            {{ end }}
+
+            <div class="abstract">
+              {{ with .Params.abstract }}
+                {{ . | markdownify }}
+              {{ else }}
+                <p>{{ .Summary }}</p>
+              {{ end }}
+            </div>
+          </div>
+        </a>
+      </article>
+      {{ end }}
+    {{ end }}
+  </div>
 </div>
 
-
 <style>
+  .article-list {
+    width: min(var(--page-width), 100%);
+    margin: 0 auto;
+    padding: 3.75rem 0 2rem;
+  }
+
+  .articles-collection {
+    margin: 0;
+  }
+
+  .post-preview {
+    display: grid;
+    grid-template-columns: minmax(88px, 15%) minmax(0, 1fr);
+    column-gap: 2rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 1.5rem 0;
+  }
+
+  .post-preview:last-of-type {
+    border-bottom: none;
+  }
+
+  .metadata {
+    font-size: 12px;
+    line-height: 1.4;
+    color: rgba(0, 0, 0, 0.62);
+    padding-top: 0.2rem;
+  }
+
+  .published-date {
+    margin-bottom: 0.9rem;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .tag {
+    display: inline-block;
+    color: rgba(0, 0, 0, 0.67);
+    padding: 0.3em 0.5em;
+    margin: 0;
+    font-size: 0.8em;
+    border: 1px solid rgba(0, 0, 0, 0.4);
+    border-radius: 3px;
+    text-transform: uppercase;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+
+  .tag.peer-reviewed {
+    background-color: rgba(15, 46, 61, 0.88);
+    color: #fff;
+    border-color: #0f2e3d;
+  }
+
+  .post-link {
+    display: grid;
+    grid-template-columns: minmax(0, 40%) minmax(220px, 35%);
+    column-gap: 5%;
+    align-items: start;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .thumbnail {
+    order: 2;
+    align-self: start;
+  }
+
+  .thumbnail img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .post-link.no-thumbnail {
+    grid-template-columns: 1fr;
+  }
+
+  .description {
+    order: 1;
+  }
+
+  .description.no-thumbnail {
+    max-width: 42rem;
+  }
+
+  .title {
+    margin: 0 0 0.35rem;
+    line-height: 1.2;
+    font-size: 24px;
+    font-weight: 700;
+    color: rgba(0, 0, 0, 0.82);
+    transition: color 0.15s ease;
+  }
+
+  .post-link:hover .title {
+    color: #004276;
+  }
+
+  .authors {
+    margin: 0 0 1rem;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.45;
+    color: rgba(0, 0, 0, 0.67);
+  }
+
+  .abstract {
+    color: rgba(0, 0, 0, 0.8);
+  }
+
+  .abstract p {
+    margin: 0;
+    font-size: 16px;
+    line-height: 1.5;
+  }
+
+  @media (min-width: 768px) {
+    .title {
+      font-size: 26px;
+    }
+  }
+
+  @media (max-width: 767px) {
     .article-list {
-        max-width: var(--main-width);
-        margin: 0 auto;
-        padding-top: 0.25rem;
-        padding-bottom: 2rem;
+      padding-top: 1.5rem;
     }
 
-    .articles-collection {
-        position: relative;
-        max-width: calc(var(--main-width) + 7rem);
-        margin: -0.5rem auto 0;
+    .post-preview {
+      grid-template-columns: 1fr;
+      row-gap: 1rem;
     }
 
-    .article-card {
-        position: relative;
-        padding: 0;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    .metadata {
+      padding-top: 0;
     }
 
-    .article-card:last-child {
-        border-bottom: none;
+    .published-date {
+      margin-bottom: 0.5rem;
     }
 
-    .article-card-link {
-        display: grid;
-        grid-template-columns: 5rem 1fr;
-        gap: 2rem;
-        padding: 1rem 0;
-        text-decoration: none;
-        color: inherit;
-        margin-left: -7rem;
-        padding-left: 7rem;
+    .post-link {
+      grid-template-columns: 1fr;
+      row-gap: 1rem;
     }
 
-    .title-text {
-        color: rgba(0, 0, 0, 0.9);
-        transition: color 0.2s ease;
+    .thumbnail {
+      order: 0;
+      max-width: 500px;
+      margin-bottom: 0.25rem;
     }
 
-    .article-card-link:hover .title-text {
-        color: #0366d6;
+    .title {
+      font-size: 24px;
     }
-
-    .article-date {
-        text-align: right;
-        line-height: 1.5;
-        padding-top: 0.5rem;
-    }
-
-    .article-date time {
-        font-family: var(--font-primary);
-        font-size: 0.85rem;
-        color: rgba(0, 0, 0, 0.6);
-    }
-
-    .article-main-content {
-        position: relative;
-    }
-
-    .article-content {
-        position: relative;
-        padding-right: 200px;
-    }
-
-    .article-title {
-        margin: 0.25rem 0;
-        line-height: 1.3;
-        font-size: 1.5rem;
-    }
-
-    .article-meta {
-        margin-bottom: 0.25rem;
-    }
-
-    .article-authors {
-        color: rgba(0, 0, 0, 0.7);
-        font-size: 0.95rem;
-        margin-bottom: 0.5rem;
-    }
-
-    .article-abstract {
-        color: rgba(0, 0, 0, 0.8);
-        line-height: 1.6;
-        font-size: 0.95rem;
-        margin-top: 1rem;
-    }
-
-    .article-thumbnail {
-        position: absolute;
-        top: 0;
-        right: 0;
-        width: 180px;
-        height: 135px;
-        overflow: hidden;
-        border-radius: 4px;
-    }
-
-    .article-thumbnail img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        object-position: center;
-    }
-
-    .article-tag {
-        font-size: 0.7rem;
-        text-transform: uppercase;
-        padding: 0.2rem 0.5rem;
-        border-radius: 3px;
-        font-weight: 600;
-        letter-spacing: 0.5px;
-    }
-
-    .peer-reviewed {
-        background: rgba(0, 0, 0, 0.1);
-        color: rgba(0, 0, 0, 0.7);
-    }
-
-    .draft {
-        background: #fff3cd;
-        color: #856404;
-        border: 1px solid #ffeeba;
-    }
-
-    .draft-info {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        margin-left: 1rem;
-    }
-
-    .progress-bar {
-        width: 100px;
-        height: 6px;
-        background: rgba(0, 0, 0, 0.1);
-        border-radius: 3px;
-        overflow: hidden;
-    }
-
-    .progress {
-        height: 100%;
-        background: #856404;
-        transition: width 0.3s ease;
-    }
-
-    @media (max-width: 768px) {
-        .article-card-link {
-            grid-template-columns: 1fr;
-            gap: 1rem;
-            margin-left: 0;
-            padding-left: 0;
-        }
-
-        .article-date {
-            text-align: left;
-        }
-
-        .article-content {
-            padding-right: 0;
-        }
-
-        .article-thumbnail {
-            position: relative;
-            width: 100%;
-            height: 200px;
-            margin-top: 1rem;
-        }
-
-        .draft-info {
-            flex-wrap: wrap;
-            margin-left: 0;
-            margin-top: 0.5rem;
-        }
-    }
-
-    @media (max-width: 480px) {
-        .article-title {
-            font-size: 1.25rem;
-        }
-
-        .article-abstract {
-            font-size: 0.9rem;
-        }
-    }
+  }
 </style>
 {{ end }}

--- a/themes/hugo-distill/layouts/_default/single.html
+++ b/themes/hugo-distill/layouts/_default/single.html
@@ -1,188 +1,384 @@
 {{ define "main" }}
-<header class="article-header">
-    <h1>{{ .Title }}</h1>
-    <div class="byline">
-        <!-- Date -->
-        <time datetime="{{ .Date.Format "2006-01-02" }}">
-            {{ .Date.Format "January 2, 2006" }}
-        </time>
-        
-        <!-- Authors -->
-        {{ with .Params.authors }}
-            <div class="authors">
-                {{ delimit . ", " }}
-            </div>
-        {{ else }}
-            {{ with .Params.author }}
-            <div class="authors">
-                {{ . }}
-            </div>
-            {{ end }}
-        {{ end }}
-    </div>
-</header>
-
-<div class="article-content">
-    {{ .Content }}
-</div>
-
-{{ if .Params.bibliography }}
-<div class="citations">
-    <h2>References</h2>
-    {{ partial "citation.html" . }}
-</div>
+{{ $hasTOC := gt (len (findRE `(?m)^##+\s` .RawContent)) 0 }}
+{{ $authors := .Params.authors }}
+{{ if not $authors }}
+  {{ with .Params.author }}
+    {{ $authors = slice . }}
+  {{ else }}
+    {{ with .Site.Params.author }}
+      {{ $authors = slice . }}
+    {{ end }}
+  {{ end }}
 {{ end }}
 
+<article class="article-page">
+  <header class="article-hero">
+    <div class="article-hero-inner">
+      <div class="article-hero-copy">
+        <h1>{{ .Title }}</h1>
+
+        {{ with .Params.abstract }}
+        <p class="article-dek">{{ . | plainify }}</p>
+        {{ end }}
+      </div>
+    </div>
+  </header>
+
+  <section class="article-meta-band">
+    <div class="article-meta-grid">
+      {{ with $authors }}
+      <div class="meta-group">
+        <div class="meta-label">Authors</div>
+        <div class="meta-value meta-list">
+          {{ range . }}
+          <div>{{ . }}</div>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{ with .Params.topics }}
+      <div class="meta-group">
+        <div class="meta-label">Topics</div>
+        <div class="meta-value meta-list">
+          {{ range . }}
+          <div>{{ . }}</div>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      <div class="meta-group">
+        <div class="meta-label">Published</div>
+        <div class="meta-value">{{ .Date.Format "January 2, 2006" }}</div>
+      </div>
+
+      {{ if .Params.peer_reviewed }}
+      <div class="meta-group">
+        <div class="meta-label">Status</div>
+        <div class="meta-value">Peer-reviewed</div>
+      </div>
+      {{ end }}
+    </div>
+  </section>
+
+  <div class="article-body-shell{{ if not $hasTOC }} no-toc{{ end }}">
+    {{ if $hasTOC }}
+    <aside class="article-toc">
+      <div class="toc-sticky">
+        <h2>Contents</h2>
+        {{ .TableOfContents }}
+      </div>
+    </aside>
+    {{ end }}
+
+    <div class="article-main-column">
+      <div class="article-content">
+        {{ .Content }}
+      </div>
+
+      {{ if .Params.bibliography }}
+      <section class="citations">
+        <h2>References</h2>
+        {{ partial "citation.html" . }}
+      </section>
+      {{ end }}
+    </div>
+  </div>
+</article>
 
 <style>
-    .article-header {
-        margin-bottom: 2rem;
-        padding-bottom: 1rem;
+  .article-page {
+    padding-top: 0.5rem;
+  }
+
+  .article-hero {
+    padding: 2.6rem 0 2.2rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .article-hero-inner,
+  .article-meta-grid,
+  .article-body-shell {
+    width: min(var(--page-width), 100%);
+    margin: 0 auto;
+  }
+
+  .article-hero-copy {
+    max-width: 560px;
+    margin-left: 0;
+  }
+
+  .article-hero h1 {
+    margin: 0;
+    font-size: clamp(2.45rem, 5vw, 4rem);
+    line-height: 1.03;
+    letter-spacing: -0.04em;
+    color: rgba(0, 0, 0, 0.97);
+  }
+
+  .article-dek {
+    margin: 1rem 0 0;
+    font-size: 18px;
+    line-height: 1.55;
+    color: rgba(0, 0, 0, 0.75);
+    max-width: 48rem;
+  }
+
+  .article-meta-band {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .article-meta-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 2rem;
+    padding: 1.35rem 0 1.25rem;
+  }
+
+  .meta-group {
+    min-width: 0;
+  }
+
+  .meta-label {
+    margin-bottom: 0.45rem;
+    font-size: 11px;
+    line-height: 1.4;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: rgba(0, 0, 0, 0.45);
+    font-weight: 600;
+  }
+
+  .meta-value {
+    font-size: 14px;
+    line-height: 1.45;
+    color: rgba(0, 0, 0, 0.74);
+    font-weight: 600;
+  }
+
+  .meta-list > div + div {
+    margin-top: 0.15rem;
+  }
+
+  .article-body-shell {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 720px);
+    gap: 2.75rem;
+    align-items: start;
+    padding-top: 1.6rem;
+  }
+
+  .article-body-shell.no-toc {
+    grid-template-columns: minmax(0, 720px);
+    justify-content: start;
+  }
+
+  .article-toc {
+    min-width: 0;
+  }
+
+  .toc-sticky {
+    position: sticky;
+    top: 1.5rem;
+    padding-right: 1.5rem;
+    border-right: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .toc-sticky h2 {
+    margin: 0 0 1rem;
+    font-size: 18px;
+    line-height: 1.2;
+    color: rgba(0, 0, 0, 0.62);
+  }
+
+  .article-toc nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .article-toc nav li {
+    margin: 0 0 0.5rem;
+    font-size: 14px;
+    line-height: 1.35;
+  }
+
+  .article-toc nav ul ul {
+    margin-top: 0.4rem;
+    padding-left: 0.75rem;
+  }
+
+  .article-toc a {
+    text-decoration: none;
+    color: rgba(0, 0, 0, 0.62);
+  }
+
+  .article-toc a:hover {
+    color: #004276;
+  }
+
+  .article-main-column {
+    min-width: 0;
+  }
+
+  .article-content {
+    color: rgba(0, 0, 0, 0.8);
+    overflow-wrap: break-word;
+  }
+
+  .article-content > :first-child {
+    margin-top: 0;
+  }
+
+  .article-content p,
+  .article-content ul,
+  .article-content ol {
+    font-size: 16px;
+    line-height: 1.75;
+    margin-bottom: 1.25rem;
+  }
+
+  .article-content p.lead,
+  .article-content blockquote {
+    font-size: 19px;
+    line-height: 1.6;
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .article-content h2 {
+    margin: 2.8rem 0 1rem;
+    font-size: 28px;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+  }
+
+  .article-content h3 {
+    margin: 2rem 0 0.8rem;
+    font-size: 21px;
+    line-height: 1.2;
+  }
+
+  .article-content img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 2rem auto;
+  }
+
+  .article-content table {
+    width: 100%;
+    display: block;
+    overflow-x: auto;
+    margin: 2rem 0;
+    border-collapse: collapse;
+  }
+
+  .article-content table th,
+  .article-content table td {
+    padding: 0.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .article-content pre {
+    max-width: 100%;
+    overflow-x: auto;
+    margin: 1.75rem 0;
+    padding: 1rem 1.15rem;
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 4px;
+  }
+
+  .article-content code {
+    font-family: "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.9em;
+  }
+
+  .article-content :not(pre) > code {
+    padding: 0.15em 0.35em;
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 3px;
+  }
+
+  .katex-display {
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-width: 100%;
+    padding: 0.5rem 0;
+    margin: 1.5rem 0;
+  }
+
+  .citations {
+    margin-top: 3rem;
+    padding-top: 1.8rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .citations h2 {
+    margin: 0 0 1rem;
+    font-size: 30px;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+  }
+
+  @media (max-width: 1080px) {
+    .article-hero-copy {
+      max-width: 44rem;
     }
 
-    .article-header h1 {
-        font-size: 2.5rem;
-        color: rgba(0, 0, 0, 0.9);
-        margin-bottom: 1rem;
+    .article-meta-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1.5rem;
     }
 
-    .byline {
-        display: flex;
-        gap: 1rem;
-        align-items: center;
-        color: rgba(0, 0, 0, 0.6);
-        font-size: 0.9rem;
+    .article-body-shell {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
     }
 
-    .authors {
-        display: flex;
-        align-items: center;
+    .article-body-shell.no-toc {
+      justify-content: stretch;
     }
 
-    .authors::before {
-        content: "•";
-        margin-right: 1rem;
+    .toc-sticky {
+      position: static;
+      padding-right: 0;
+      border-right: 0;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+      padding-bottom: 1rem;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .article-page {
+      padding-top: 0;
     }
 
-    .article-content {
-        margin-top: 2rem;
-        font-family: var(--font-primary);
-        line-height: 1.7;
-        color: rgba(0, 0, 0, 0.8);
-        width: 100%;
-        overflow-wrap: break-word;
-        word-wrap: break-word;
+    .article-hero {
+      padding: 1.8rem 0 1.6rem;
     }
 
-    /* Make images responsive */
-    .article-content img {
-        max-width: 100%;
-        height: auto;
-        display: block;
-        margin: 2rem auto;
+    .article-dek {
+      font-size: 17px;
     }
 
-    /* Handle tables */
-    .article-content table {
-        width: 100%;
-        overflow-x: auto;
-        display: block;
-        border-collapse: collapse;
-        margin: 2rem 0;
+    .article-meta-grid {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+      padding: 1.1rem 0;
     }
 
-    .article-content table th,
-    .article-content table td {
-        padding: 0.75rem;
-        border: 1px solid rgba(0, 0, 0, 0.1);
+    .article-content h2 {
+      font-size: 24px;
     }
 
-    /* Make code blocks responsive */
-    .article-content pre {
-        max-width: 100%;
-        overflow-x: auto;
-        padding: 1rem;
-        background: rgba(0, 0, 0, 0.05);
-        border-radius: 4px;
-        margin: 1.5rem 0;
-    }
-
-    .article-content code {
-        font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace;
-        font-size: 0.9em;
-        padding: 0.2em 0.4em;
-        background: rgba(0, 0, 0, 0.05);
-        border-radius: 3px;
-    }
-
-    .article-content pre code {
-        background: none;
-        padding: 0;
-    }
-
-    /* Math content */
-    .katex-display {
-        overflow-x: auto;
-        overflow-y: hidden;
-        max-width: 100%;
-        padding: 0.5rem 0;
-        margin: 1.5rem 0;
-    }
-
-    /* Citations section */
-    .citations {
-        margin-top: 4rem;
-        padding-top: 2rem;
-        border-top: 1px solid rgba(0, 0, 0, 0.1);
+    .article-content h3 {
+      font-size: 19px;
     }
 
     .citations h2 {
-        font-size: 1.5rem;
-        margin-bottom: 1.5rem;
+      font-size: 26px;
     }
-
-    /* Responsive adjustments */
-    @media (max-width: 768px) {
-        .article-header h1 {
-            font-size: 2rem;
-        }
-
-        .byline {
-            flex-wrap: wrap;
-            gap: 0.5rem;
-        }
-
-        .authors::before {
-            margin-right: 0.5rem;
-        }
-
-        .article-content {
-            font-size: 0.95rem;
-        }
-
-        .citations {
-            margin-top: 3rem;
-        }
-    }
-
-    @media (max-width: 480px) {
-        .article-header h1 {
-            font-size: 1.75rem;
-        }
-
-        .byline {
-            font-size: 0.85rem;
-        }
-
-        .article-content pre {
-            padding: 0.75rem;
-            font-size: 0.85rem;
-        }
-
-        .citations h2 {
-            font-size: 1.25rem;
-        }
-    }
+  }
 </style>
-
 {{ end }}

--- a/themes/hugo-distill/layouts/about/list.html
+++ b/themes/hugo-distill/layouts/about/list.html
@@ -1,103 +1,146 @@
 {{ define "main" }}
-<div class="article-list">
-  <div class="articles-collection">{{ .Content }}</div>
-</div>
+<article class="about-page">
+  <header class="about-hero">
+    <div class="about-hero-inner">
+      <h1>{{ .Title }}</h1>
+    </div>
+  </header>
+
+  <div class="about-body">
+    <div class="about-content">
+      {{ .Content }}
+    </div>
+  </div>
+</article>
 
 <style>
-  /* Reset browser defaults first */
-  .articles-collection h2,
-  .articles-collection p {
-    margin-block-start: 0;
-    margin-block-end: 0;
+  .about-page {
+    padding-top: 0.5rem;
+  }
+
+  .about-hero {
+    padding: 2.2rem 0 1.2rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .about-hero-inner,
+  .about-body {
+    width: min(var(--page-width), 100%);
+    margin: 0 auto;
+  }
+
+  .about-hero h1 {
     margin: 0;
+    font-size: clamp(2.3rem, 5vw, 3.5rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+    color: rgba(0, 0, 0, 0.96);
   }
 
-  .article-list {
-    max-width: var(--main-width);
-    margin: 0 auto;
-    padding-top: 0.25rem;
-    padding-bottom: 2rem;
+  .about-body {
+    padding-top: 1.75rem;
   }
 
-  .articles-collection {
-    position: relative;
-    max-width: calc(var(--main-width) + 7rem);
-    margin: 0 auto;
+  .about-content {
+    max-width: 720px;
   }
 
-  /* Intro paragraph */
-  .articles-collection > p:first-of-type {
-    margin-bottom: 1.5rem;
+  .about-content > :first-child {
+    margin-top: 0;
   }
 
-  /* Headings */
-  .articles-collection h2 {
-    font-size: 1.5rem;
+  .about-content > p:first-of-type {
+    font-size: 20px;
+    line-height: 1.65;
+    color: rgba(0, 0, 0, 0.72);
+    margin-bottom: 2rem;
+  }
+
+  .about-content h2 {
+    margin: 2.4rem 0 0.75rem;
+    font-size: 32px;
+    line-height: 1.12;
+    letter-spacing: -0.02em;
     color: rgba(0, 0, 0, 0.9);
-    margin-top: 1rem;
-    margin-bottom: 0.25rem;
   }
 
-  .articles-collection h3 {
-    font-size: 1.2rem;
-    color: rgba(0, 0, 0, 0.9);
-    margin-top: 1rem;
-    margin-bottom: 0.25rem;
+  .about-content h3 {
+    margin: 1.5rem 0 0.5rem;
+    font-size: 22px;
+    line-height: 1.2;
+    color: rgba(0, 0, 0, 0.85);
   }
 
-  /* Lists */
-  .articles-collection ul {
-    list-style-type: none;
-    padding-left: 0;
-    margin-top: 0.25rem;
-    margin-bottom: 1rem;
-  }
-
-  .articles-collection ul li {
-    position: relative;
-    padding-left: 1.5rem;
-    margin-bottom: 0.25rem;
+  .about-content p {
+    margin: 0 0 1rem;
+    font-size: 17px;
+    line-height: 1.75;
     color: rgba(0, 0, 0, 0.8);
   }
 
-  .articles-collection ul li:before {
-    content: '•';
-    position: absolute;
-    left: 0;
-    color: rgba(0, 0, 0, 0.6);
+  .about-content ul {
+    margin: 0.5rem 0 1.5rem 1.2rem;
+    padding: 0;
   }
 
-  /* General paragraphs */
-  .articles-collection p {
-    margin-bottom: 0.5rem;
+  .about-content li {
+    margin: 0 0 0.45rem;
+    padding-left: 0.2rem;
+    font-size: 17px;
+    line-height: 1.7;
     color: rgba(0, 0, 0, 0.8);
   }
 
-  /* Links */
-  .articles-collection a {
-    color: #0366d6;
+  .about-content strong {
+    color: rgba(0, 0, 0, 0.92);
+  }
+
+  .about-content em {
+    color: rgba(0, 0, 0, 0.68);
+  }
+
+  .about-content a {
+    color: #004276;
     text-decoration: none;
-    transition: color 0.2s ease;
   }
 
-  .articles-collection a:hover {
-    color: #0056b3;
+  .about-content a:hover {
     text-decoration: underline;
   }
 
-  /* CV Button */
-  .cv-button {
+  .about-content br + a,
+  .about-content br + em,
+  .about-content br + strong {
     display: inline-block;
-    padding: 0.75rem 1.5rem;
-    background-color: rgba(0, 0, 0, 0.05);
-    border-radius: 4px;
-    margin-top: 0.5rem;
-    transition: background-color 0.2s ease;
+    margin-top: 0.2rem;
   }
 
-  .cv-button:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-    text-decoration: none;
+  @media (max-width: 767px) {
+    .about-page {
+      padding-top: 0;
+    }
+
+    .about-hero {
+      padding: 1.6rem 0 1rem;
+    }
+
+    .about-content > p:first-of-type {
+      font-size: 18px;
+      margin-bottom: 1.5rem;
+    }
+
+    .about-content h2 {
+      font-size: 26px;
+    }
+
+    .about-content h3 {
+      font-size: 20px;
+    }
+
+    .about-content p,
+    .about-content li {
+      font-size: 16px;
+    }
   }
 </style>
 {{ end }}

--- a/themes/hugo-distill/layouts/partials/footer.html
+++ b/themes/hugo-distill/layouts/partials/footer.html
@@ -1,317 +1,79 @@
-<!-- layouts/partials/footer.html -->
-<div class="footer-container">
-  <div class="footer-content">
-    <!-- Quote Section -->
-    <div class="footer-quote">
-      <p>"The best way to predict the future is to invent it."</p>
-      <span class="quote-author">— Alan Kay</span>
-    </div>
+<div class="site-footer-inner">
+  <div class="footer-description">
+    <a href="/" class="footer-logo" aria-label="{{ .Site.Title }} home">{{ .Site.Title }}</a>
+    <span class="footer-tagline">{{ .Site.Params.description }}</span>
+  </div>
 
-    <!-- Social Links -->
-    <div class="social-links">
-      {{ with .Site.Params.social.twitter }}
-      <a
-        href="https://twitter.com/{{ . }}"
-        class="social-link"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Twitter profile"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path
-            d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"
-          ></path>
-        </svg>
-        <span class="sr-only">Twitter</span>
-      </a>
-      {{ end }} {{ with .Site.Params.social.linkedin }}
-      <a
-        href="https://linkedin.com/{{ . }}"
-        class="social-link"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="LinkedIn profile"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path
-            d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"
-          ></path>
-          <rect x="2" y="9" width="4" height="12"></rect>
-          <circle cx="4" cy="4" r="2"></circle>
-        </svg>
-        <span class="sr-only">LinkedIn</span>
-      </a>
-      {{ end }} {{ with .Site.Params.social.github }}
-      <a
-        href="https://github.com/{{ . }}"
-        class="social-link"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="GitHub profile"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path
-            d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
-          ></path>
-        </svg>
-        <span class="sr-only">GitHub</span>
-      </a>
-      {{ end }}
-    </div>
+  <div class="footer-nav">
+    <a href="/about/">About</a>
+    {{ with .Site.Params.social.github }}
+    <a href="https://github.com/{{ . }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+    {{ end }}
+    {{ with .Site.Params.social.twitter }}
+    <a href="https://twitter.com/{{ . }}" target="_blank" rel="noopener noreferrer">Twitter</a>
+    {{ end }}
   </div>
 </div>
 
-<!-- <style>
-  .footer-container {
-    width: 100%;
-    height: 100%;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    background-color: #fff;
-    display: flex;
-    align-items: center;
-  }
-
-  .footer-content {
-    max-width: var(--main-width);
-    width: 100%;
-    margin: 0 auto;
-    padding: 0 var(--gutter);
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: center;
-    gap: 2rem;
-  }
-
-  .footer-quote {
-    color: rgba(0, 0, 0, 0.7);
-    font-style: italic;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .footer-quote p {
-    margin: 0;
-    font-size: 0.9rem;
-    line-height: 1.5;
-  }
-
-  .quote-author {
-    font-size: 0.8rem;
-    color: rgba(0, 0, 0, 0.5);
-    font-style: normal;
-  }
-
-  .social-links {
-    display: flex;
-    gap: 1.5rem;
-    align-items: center;
-  }
-
-  .social-link {
-    color: rgba(0, 0, 0, 0.6);
-    transition: color 0.2s ease;
-    display: flex;
-    align-items: center;
-  }
-
-  .social-link:hover {
-    color: rgba(0, 0, 0, 0.9);
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-  }
-
-  /* Responsive adjustments */
-  @media (max-width: 640px) {
-    .footer-content {
-      grid-template-columns: 1fr;
-      text-align: center;
-      gap: 0.5rem;
-    }
-
-    .social-links {
-      justify-content: center;
-    }
-
-    .footer-quote {
-      display: none;
-    }
-  }
-</style> -->
-
 <style>
-  .footer-container {
-    width: 100%;
-    height: 100%;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    background-color: #fff;
-    display: flex;
-    align-items: center;
-  }
-
-  .footer-content {
-    max-width: var(--main-width);
-    width: 100%;
+  .site-footer-inner {
+    width: min(var(--page-width), calc(100vw - 2 * var(--gutter)));
     margin: 0 auto;
-    padding: 0 var(--gutter);
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: center;
+    padding: 1.2rem 0 1.5rem;
+    color: rgba(255, 255, 255, 0.8);
+    display: flex;
+    justify-content: space-between;
     gap: 2rem;
-    min-height: var(--nav-height);
+    align-items: flex-start;
   }
 
-  .footer-quote {
-    color: rgba(0, 0, 0, 0.7);
-    font-style: italic;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .footer-quote p {
-    margin: 0;
-    font-size: 0.9rem;
+  .footer-description {
+    font-size: 13px;
     line-height: 1.5;
-  }
-
-  .quote-author {
-    font-size: 0.8rem;
-    color: rgba(0, 0, 0, 0.5);
-    font-style: normal;
-  }
-
-  .social-links {
     display: flex;
-    gap: 1.5rem;
-    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: baseline;
   }
 
-  .social-link {
-    color: rgba(0, 0, 0, 0.6);
-    transition: color 0.2s ease;
+  .footer-logo {
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+    font-size: 17px;
+    font-weight: 400;
+  }
+
+  .footer-logo:hover,
+  .footer-nav a:hover {
+    color: #fff;
+  }
+
+  .footer-tagline {
+    color: rgba(255, 255, 255, 0.65);
+  }
+
+  .footer-nav {
+    font-size: 13px;
+    line-height: 1.6;
     display: flex;
-    align-items: center;
-    padding: 0.5rem;
-    border-radius: 50%;
-    background: transparent;
-    transition: all 0.2s ease;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.75rem;
   }
 
-  .social-link:hover {
-    color: rgba(0, 0, 0, 0.9);
-    background: rgba(0, 0, 0, 0.05);
+  .footer-nav a {
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
   }
 
-  .social-link svg {
-    width: 20px;
-    height: 20px;
-    stroke-width: 2px;
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-  }
-
-  @media (max-width: 768px) {
-    .footer-content {
-      grid-template-columns: 1fr;
-      text-align: center;
-      gap: 1rem;
-      padding: 1.5rem var(--gutter);
+  @media (max-width: 720px) {
+    .site-footer-inner {
+      flex-direction: column;
+      gap: 0.65rem;
     }
 
-    .social-links {
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 1rem;
-    }
-  }
-
-  @media (max-width: 640px) {
-    .footer-quote {
-      display: none;
-    }
-
-    .footer-content {
-      padding: 1rem var(--gutter);
-    }
-  }
-
-  @media (max-width: 480px) {
-    .footer-container {
-      padding: 0.5rem 0;
-    }
-
-    .social-links {
-      gap: 0.75rem;
-    }
-
-    .social-link {
-      padding: 0.4rem;
-    }
-
-    .social-link svg {
-      width: 18px;
-      height: 18px;
-    }
-  }
-
-  /* Add smooth hover transitions for touch devices */
-  @media (hover: none) {
-    .social-link {
-      transition: none;
-    }
-
-    .social-link:active {
-      background: rgba(0, 0, 0, 0.05);
-      color: rgba(0, 0, 0, 0.9);
+    .footer-nav {
+      justify-content: flex-start;
     }
   }
 </style>

--- a/themes/hugo-distill/layouts/partials/head.html
+++ b/themes/hugo-distill/layouts/partials/head.html
@@ -3,23 +3,22 @@
   name="viewport"
   content="width=device-width, initial-scale=1.0, maximum-scale=5.0"
 />
-<meta name="theme-color" content="#ffffff" />
+<meta name="theme-color" content="#0f2e3d" />
 
 <title>
   {{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{
   end }}
 </title>
 
-<!-- Favicon -->
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
 <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
-<!-- Smooth scrolling -->
 <style>
   html {
     scroll-behavior: smooth;
-    scrollbar-gutter: stable;
-    -webkit-overflow-scrolling: touch;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -28,89 +27,51 @@
     }
   }
 
-  /* Improved font rendering */
-  * {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
   }
 </style>
 
-<!-- Libre Franklin font -->
-<style>
-  @font-face {
-    font-family: 'Libre Franklin';
-    src: url('/fonts/libre-franklin/LibreFranklin-Regular.woff2')
-        format('woff2'),
-      url('/fonts/libre-franklin/LibreFranklin-Regular.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
-    font-display: swap;
-  }
-
-  @font-face {
-    font-family: 'Libre Franklin';
-    src: url('/fonts/libre-franklin/LibreFranklin-Bold.woff2') format('woff2'),
-      url('/fonts/libre-franklin/LibreFranklin-Bold.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
-    font-display: swap;
-  }
-</style>
-
-<!-- Main styles -->
 <style>
   :root {
-    --main-width: min(850px, 95vw);
-    --side-width: min(250px, 25vw);
-    --gutter: clamp(16px, 4vw, 40px);
-    --nav-height: clamp(3rem, 4vw, 4rem);
-    --font-primary: 'Libre Franklin', -apple-system, BlinkMacSystemFont,
-      sans-serif;
+    --page-width: 984px;
+    --article-width: 720px;
+    --side-width: 220px;
+    --gutter: clamp(16px, 4vw, 32px);
+    --nav-height: 60px;
+    --brand-ink: hsl(200, 60%, 15%);
+    --font-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif;
   }
 
   html {
-    font-size: clamp(14px, 1vw + 8px, 18px);
+    font: 400 16px/1.55em var(--font-primary);
+    background: #fff;
   }
 
   body {
-    font-family: var(--font-primary);
-    line-height: 1.7;
-    color: rgba(0, 0, 0, 0.8);
     margin: 0;
-    padding: 0;
+    color: rgba(0, 0, 0, 0.8);
     counter-reset: sidenote-counter;
+    background: #fff;
+  }
+
+  a {
+    color: #004276;
+  }
+
+  p,
+  ul,
+  ol {
     font-size: 16px;
+    line-height: 1.55;
   }
 
-  .container {
-    width: 100%;
-    max-width: calc(var(--main-width) + 2 * var(--gutter));
-    margin: 0 auto;
-    padding: 0 var(--gutter);
-    overflow-x: hidden;
-  }
-
-  .distill-article {
-    position: relative;
-    width: var(--main-width);
-    width: 100%;
-    margin: 0 auto;
-  }
-
-  /* Sidenote styles */
-  .sidenote {
-    float: right;
-    clear: right;
-    margin-right: calc(-1 * (var(--side-width) + var(--gutter)));
-    width: var(--side-width);
-    font-size: 0.8em;
-    line-height: 1.4;
-    vertical-align: baseline;
-    position: relative;
-  }
-
-  /* Typography */
   h1,
   h2,
   h3,
@@ -118,150 +79,53 @@
   h5,
   h6 {
     font-family: var(--font-primary);
-    font-weight: 600;
-    line-height: 1.2;
+    color: rgba(0, 0, 0, 0.84);
+    line-height: 1.15;
+    margin-top: 0;
   }
 
   h1 {
-    font-size: 2.5em;
-    margin-bottom: 1em;
+    font-size: clamp(2rem, 4vw, 3rem);
+    font-weight: 700;
   }
 
-  p {
-    margin-bottom: 1.5em;
+  h2 {
+    font-size: clamp(1.6rem, 3vw, 2.1rem);
+    font-weight: 700;
   }
 
-  /* Article List and Card Styles */
-  .article-list {
-    max-width: var(--main-width);
+  .container {
+    width: min(var(--page-width), calc(100vw - 2 * var(--gutter)));
     margin: 0 auto;
-    padding: 4rem 0;
+    overflow-x: hidden;
   }
 
-  .articles-collection {
-    display: flex;
-    flex-direction: column;
-    gap: 3rem;
+  .distill-article {
+    position: relative;
+    width: 100%;
+    margin: 0 auto;
   }
 
-  .article-card {
-    padding: 2rem 0;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  .sidenote {
+    float: right;
+    clear: right;
+    margin-right: calc(-1 * (var(--side-width) + 2rem));
+    width: var(--side-width);
+    font-size: 0.8em;
+    line-height: 1.4;
+    vertical-align: baseline;
+    position: relative;
   }
 
-  .article-card:last-child {
-    border-bottom: none;
-  }
-
-  .article-meta {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    margin-bottom: 0.5rem;
-    font-family: var(--font-primary);
-  }
-
-  .article-meta time {
-    color: rgba(0, 0, 0, 0.6);
-    font-size: 0.9rem;
-  }
-
-  .article-title {
-    font-size: 1.8rem;
-    margin-bottom: 0.5rem;
-    line-height: 1.3;
-  }
-
-  .article-title a {
-    color: rgba(0, 0, 0, 0.9);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .article-title a:hover {
-    color: #0366d6;
-  }
-
-  .article-authors {
-    color: rgba(0, 0, 0, 0.7);
-    margin: 0.5rem 0;
-    font-size: 1rem;
-  }
-
-  .article-abstract {
-    color: rgba(0, 0, 0, 0.8);
-    line-height: 1.7;
-    margin-top: 1rem;
-  }
-
-  /* Article Tags and Status */
-  .article-tag {
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    padding: 0.2rem 0.5rem;
-    border-radius: 3px;
-    font-weight: 600;
-    letter-spacing: 0.5px;
-  }
-
-  .peer-reviewed {
-    background: rgba(0, 0, 0, 0.1);
-    color: rgba(0, 0, 0, 0.7);
-  }
-
-  .draft {
-    background: #fff3cd;
-    color: #856404;
-    border: 1px solid #ffeeba;
-  }
-
-  .draft-info {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    margin-left: 1rem;
-  }
-
-  /* Progress Bar */
-  .progress-bar {
-    width: 100px;
-    height: 6px;
-    background: rgba(0, 0, 0, 0.1);
-    border-radius: 3px;
-    overflow: hidden;
-  }
-
-  .progress {
-    height: 100%;
-    background: #856404;
-    transition: width 0.3s ease;
-  }
-
-  /* Responsive Styles */
-  @media (max-width: 768px) {
-    .article-card {
-      grid-template-columns: 1fr;
-    }
-
-    .article-thumbnail {
+  @media (max-width: 1080px) {
+    .sidenote {
+      float: none;
+      margin: 1rem 0;
       width: 100%;
-      height: 200px;
-      order: -1;
-    }
-
-    .article-title {
-      font-size: 1.5rem;
-    }
-
-    .draft-info {
-      flex-wrap: wrap;
-      margin-left: 0;
-      margin-top: 0.5rem;
     }
   }
 </style>
 
-<!-- KaTeX for math rendering -->
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css"

--- a/themes/hugo-distill/layouts/partials/header.html
+++ b/themes/hugo-distill/layouts/partials/header.html
@@ -1,267 +1,86 @@
-<!-- layouts/partials/header.html -->
 <nav class="site-nav">
-    <div class="nav-container">
-        <!-- Site title/logo on the left -->
-        <div class="nav-left">
-            <a href="/" class="site-title">
-                <img src="/images/profile.png" alt="{{ .Site.Title }}" class="profile-image">
-                <span class="site-title-text">{{ .Site.Title }}</span>
-            </a>
-        </div>
+  <div class="nav-shell">
+    <a href="/" class="site-logo" aria-label="{{ .Site.Title }} home">{{ .Site.Title }}</a>
 
-        <!-- Navigation links on the right -->
-        <div class="nav-right">
-            <a href="/posts/" class="nav-link {{ if eq .Section "posts" }}active{{ end }}">Posts</a>
-            <a href="/about/" class="nav-link {{ if eq .Section "about" }}active{{ end }}">About</a>
-        </div>
+    <div class="site-nav-links">
+      <a href="/about/" class="nav-link {{ if eq .Section "about" }}active{{ end }}">About</a>
+      {{ with .Site.Params.social.github }}
+      <a href="https://github.com/{{ . }}" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
+      {{ end }}
+      {{ with .Site.Params.social.twitter }}
+      <a href="https://twitter.com/{{ . }}" class="nav-link" target="_blank" rel="noopener noreferrer">Twitter</a>
+      {{ end }}
     </div>
+  </div>
 </nav>
 
-<!-- <style>
-    .site-nav {
-        display: flex;
-        align-items: center;
-        width: 100%;
-        height: 100%;
-        background-color: #fff;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    }
-
-    .nav-container {
-        max-width: var(--main-width);
-        width: 100%;
-        margin: 0 auto;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0 var(--gutter);
-    }
-
-    .nav-left {
-        display: flex;
-        align-items: center;
-    }
-
-    .nav-right {
-        display: flex;
-        gap: 2rem;
-        align-items: center;
-    }
-
-    .site-title {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        text-decoration: none;
-    }
-
-    .profile-image {
-        width: 40px;
-        height: 40px;
-        border-radius: 50%;
-        object-fit: cover;
-        border: 2px solid rgba(0, 0, 0, 0.1);
-        transition: border-color 0.2s ease;
-    }
-
-    .site-title:hover .profile-image {
-        border-color: rgba(0, 0, 0, 0.3);
-    }
-
-    .site-title-text {
-        font-size: 1.2rem;
-        font-weight: 600;
-        color: rgba(0, 0, 0, 0.9);
-    }
-
-    /* Reset any text decoration */
-    .site-nav a {
-        text-decoration: none !important;
-    }
-
-    .nav-link {
-        position: relative;
-        color: rgba(0, 0, 0, 0.7);
-        font-size: 1rem;
-        padding: 0.5rem 0;
-        border-bottom: 2px solid transparent !important;
-        transition: all 0.2s ease;
-    }
-
-    .nav-link::after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        height: 2px;
-        background-color: transparent;
-        transition: background-color 0.2s ease;
-    }
-
-    .nav-link:hover::after {
-        background-color: rgba(0, 0, 0, 0.2);
-    }
-
-    .nav-link.active::after {
-        background-color: rgba(0, 0, 0, 0.9);
-    }
-
-    /* Responsive adjustments */
-    @media (max-width: 640px) {
-        .site-title-text {
-            display: none;
-        }
-
-        .site-title {
-            gap: 0;
-        }
-
-        .profile-image {
-            width: 35px;
-            height: 35px;
-        }
-    }
-</style> -->
-
 <style>
-    .site-nav {
-        display: flex;
-        align-items: center;
-        width: 100%;
-        height: 100%;
-        background-color: #fff;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-        position: sticky;
-        top: 0;
-        z-index: 1000;
+  .site-nav {
+    width: 100%;
+    background: var(--brand-ink);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.05);
+  }
+
+  .nav-shell {
+    width: min(var(--page-width), calc(100vw - 2 * var(--gutter)));
+    min-height: 60px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .site-logo,
+  .site-nav-links a {
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+  }
+
+  .site-logo {
+    font-size: 17px;
+    font-weight: 400;
+    line-height: 60px;
+  }
+
+  .site-logo:hover,
+  .site-nav-links a:hover,
+  .site-nav-links a.active {
+    color: #fff;
+  }
+
+  .site-nav-links {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .site-nav-links a {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    line-height: 60px;
+    font-weight: 400;
+  }
+
+  @media (min-width: 1080px) {
+    .nav-shell {
+      min-height: 70px;
     }
 
-    .nav-container {
-        max-width: var(--main-width);
-        width: 100%;
-        margin: 0 auto;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0 var(--gutter);
+    .site-logo,
+    .site-nav-links a {
+      line-height: 70px;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .site-nav-links {
+      gap: 1rem;
     }
 
-    .nav-left {
-        display: flex;
-        align-items: center;
+    .site-nav-links a {
+      font-size: 11px;
     }
-
-    .nav-right {
-        display: flex;
-        gap: 2rem;
-        align-items: center;
-    }
-
-    .site-title {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        text-decoration: none;
-    }
-
-    .profile-image {
-        width: 40px;
-        height: 40px;
-        border-radius: 50%;
-        object-fit: cover;
-        border: 2px solid rgba(0, 0, 0, 0.1);
-        transition: border-color 0.2s ease;
-    }
-
-    .site-title:hover .profile-image {
-        border-color: rgba(0, 0, 0, 0.3);
-    }
-
-    .site-title-text {
-        font-size: 1.2rem;
-        font-weight: 600;
-        color: rgba(0, 0, 0, 0.9);
-    }
-
-    .site-nav a {
-        text-decoration: none !important;
-    }
-
-    .nav-link {
-        position: relative;
-        color: rgba(0, 0, 0, 0.7);
-        font-size: 1rem;
-        padding: 0.5rem 0;
-        border-bottom: 2px solid transparent !important;
-        transition: all 0.2s ease;
-    }
-
-    .nav-link::after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        height: 2px;
-        background-color: transparent;
-        transition: background-color 0.2s ease;
-    }
-
-    .nav-link:hover::after {
-        background-color: rgba(0, 0, 0, 0.2);
-    }
-
-    .nav-link.active::after {
-        background-color: rgba(0, 0, 0, 0.9);
-    }
-
-    @media (max-width: 768px) {
-        .nav-container {
-            padding: 0 1rem;
-        }
-
-        .nav-right {
-            gap: 1.5rem;
-        }
-    }
-
-    @media (max-width: 640px) {
-        .site-title-text {
-            display: none;
-        }
-
-        .site-title {
-            gap: 0;
-        }
-
-        .profile-image {
-            width: 35px;
-            height: 35px;
-        }
-
-        .nav-right {
-            gap: 1rem;
-        }
-
-        .nav-link {
-            font-size: 0.9rem;
-        }
-    }
-
-    @media (max-width: 360px) {
-        .nav-container {
-            padding: 0 0.5rem;
-        }
-        
-        .nav-right {
-            gap: 0.75rem;
-        }
-
-        .profile-image {
-            width: 32px;
-            height: 32px;
-        }
-    }
+  }
 </style>
-


### PR DESCRIPTION
## What changed
- refined the Distill-inspired global theme chrome and typography
- rebuilt the homepage/article list layout to better match Distill proportions
- redesigned article detail pages with a hero, metadata band, and optional contents rail
- rebuilt the about page structure and added a short `make dev` local run target

## Why
The site was structurally close to Distill but still read like a generic personal blog in the header, footer, list layout, and article page composition.

## Impact
The site now feels much closer to the intended editorial style while keeping the EKS brand instead of copying Distill branding directly.

## Validation
- `hugo`
